### PR TITLE
Fix HWID Lock on non Win32

### DIFF
--- a/src/keyauth.rs
+++ b/src/keyauth.rs
@@ -518,11 +518,7 @@ impl KeyauthApi {
     }
 
     fn get_hwid() -> String {
-        if cfg!(windows) {
-            machine_uuid::get()
-        } else {
-            "None".to_string()
-        }
+        machine_uuid::get()
     }
 
     fn gen_init_iv() -> String {


### PR DESCRIPTION
This function call returns the HWID regardless of the operating system. See: https://docs.rs/machine_uuid/latest/machine_uuid/fn.get.html